### PR TITLE
feat: add double write feasure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ exclude = [
 [features]
 default = ["std"]
 std = []
+double-write = ["default"]
 
 [dependencies]
 bytes = "1"

--- a/src/byte_str.rs
+++ b/src/byte_str.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 
 use std::{ops, str};
+use std::hash::Hash;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct ByteStr {

--- a/src/byte_str.rs
+++ b/src/byte_str.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
 
 use std::{ops, str};
-use std::hash::Hash;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct ByteStr {

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -45,6 +45,11 @@ pub struct HdrName<'a> {
 
 impl<'a> Hash for HdrName<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        #[cfg(feature = "double-write")]
+        if let Some(original)= self.original{
+            original.hash(state);
+            return;
+        }
         self.inner.hash(state);
     }
 }

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -69,6 +69,7 @@ impl<T: PartialEq> PartialEq for Repr<T> {
 
 impl<T: Eq> Eq for Repr<T> {}
 
+#[cfg(not(feature = "double-write"))]
 impl<T: Hash> Hash for Repr<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
@@ -77,6 +78,30 @@ impl<T: Hash> Hash for Repr<T> {
         }
     }
 }
+#[cfg(feature = "double-write")]
+impl<T: Hash> Hash for Repr<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Repr::Standard(inner, src) => {
+                match src {
+                    Some(src) => src.hash(state),
+                    None => {
+                        inner.hash(state);
+                    }
+                }
+            }
+            Repr::Custom(inner, src) => {
+                match src {
+                    Some(src) => src.hash(state),
+                    None => {
+                        inner.hash(state);
+                    }
+                }
+            },
+        }
+    }
+}
+
 
 // Used to hijack the Hash impl
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -680,4 +680,7 @@ fn feature_double_write() {
     assert_eq!(headers.get(HeaderName::from_bytes("Foo".as_bytes()).unwrap()), Some(&HeaderValue::from_static("Bar")));
     assert_eq!(headers.get("foo1"), Some(&HeaderValue::from_static("baz1")));
     assert_eq!(headers.get_all("Foo1").into_iter().collect::<Vec<_>>(), vec![&HeaderValue::from_static("baz2"), &HeaderValue::from_static("baz3")]);
+    headers.remove("Foo1");
+    assert_eq!(headers.get("foo1"), Some(&HeaderValue::from_static("baz1")));
+    assert_eq!(headers.get("Foo1"), None);
 }

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use http::header::*;
 use http::*;
 
@@ -659,20 +658,20 @@ fn feature_double_write() {
     );
 
     headers.insert(
-        HeaderName::from_str("Foo").unwrap(),
+        HeaderName::from_bytes("Foo".as_bytes()).unwrap(),
         HeaderValue::from_static("Bar"),
     );
 
     headers.append(
-        HeaderName::from_str("foo1").unwrap(),
+        HeaderName::from_bytes("foo1".as_bytes()).unwrap(),
         HeaderValue::from_static("baz1"),
     );
     headers.append(
-        HeaderName::from_str("Foo1").unwrap(),
+        HeaderName::from_bytes("Foo1".as_bytes()).unwrap(),
         HeaderValue::from_static("baz2"),
     );
     headers.append(
-        HeaderName::from_str("Foo1").unwrap(),
+        HeaderName::from_bytes("Foo1".as_bytes()).unwrap(),
         HeaderValue::from_static("baz3"),
     );
 

--- a/tests/header_map.rs
+++ b/tests/header_map.rs
@@ -649,6 +649,7 @@ fn ensure_miri_sharedreadonly_not_violated() {
     let _foo = &headers.iter().next();
 }
 
+#[cfg(feature = "double-write")]
 #[test]
 fn feature_double_write() {
     let mut headers = HeaderMap::new();


### PR DESCRIPTION
To ensure backward compatibility with services that may rely on non-canonical HTTP header keys, we need to preserve both original and canonicalized header keys in downstream requests. The current implementation only keeps canonicalized (lowercase) keys, which creates risks for services accessing headers using original casing.